### PR TITLE
Allow relock in deposit function

### DIFF
--- a/contracts/VeVault.sol
+++ b/contracts/VeVault.sol
@@ -648,11 +648,6 @@ abstract contract VeVault is ReentrancyGuard, Pausable, IERC4626 {
         uint256 unlockTime = block.timestamp + lockTime;
         if (_unlockDate[receiver] < unlockTime)
             _unlockDate[receiver] = unlockTime;
-        
-        // Update assets
-        _totalManagedAssets += assets;
-        _assetBalances[receiver] += assets;
-        IERC20(_assetTokenAddress).safeTransferFrom(receiver, address(this), assets);
 
         // The end balance of shares can be
         // lower than the amount returned by
@@ -661,6 +656,10 @@ abstract contract VeVault is ReentrancyGuard, Pausable, IERC4626 {
         if (assets == 0) {
             emit Relock(msg.sender, receiver, assets, _unlockDate[receiver]);
         } else {
+            // Update assets
+            _totalManagedAssets += assets;
+            _assetBalances[receiver] += assets;
+            IERC20(_assetTokenAddress).safeTransferFrom(receiver, address(this), assets);
             emit Deposit(msg.sender, receiver, assets, shares);
         }
         return shares;

--- a/contracts/VeVault.sol
+++ b/contracts/VeVault.sol
@@ -640,8 +640,7 @@ abstract contract VeVault is ReentrancyGuard, Pausable, IERC4626 {
         ) internal 
         updateShares(receiver, lockTime)
         returns (uint256 shares) {
-        if (assets <= 0 || msg.sender != receiver
-            || lockTime < _lockTimer.min || lockTime > _lockTimer.max)
+        if (msg.sender != receiver || lockTime < _lockTimer.min || lockTime > _lockTimer.max)
             revert Unauthorized();
 
         // Update lockTime
@@ -659,7 +658,11 @@ abstract contract VeVault is ReentrancyGuard, Pausable, IERC4626 {
         // lower than the amount returned by
         // this function
         shares = convertToShares(assets, lockTime);
-        emit Deposit(msg.sender, receiver, assets, shares);
+        if (assets == 0) {
+            emit Relock(msg.sender, receiver, assets, _unlockDate[receiver]);
+        } else {
+            emit Deposit(msg.sender, receiver, assets, shares);
+        }
         return shares;
     }
     
@@ -777,6 +780,7 @@ abstract contract VeVault is ReentrancyGuard, Pausable, IERC4626 {
     
     /* ========== EVENTS ========== */
 
+    event Relock(address indexed caller, address indexed receiver, uint256 assets, uint256 newUnlockDate);
     event PayPenalty(address indexed caller, address indexed owner, uint256 assets);
     event Burn(address indexed user, uint256 shares);
     event Mint(address indexed user, uint256 shares);

--- a/contracts/VeVault.sol
+++ b/contracts/VeVault.sol
@@ -383,10 +383,13 @@ abstract contract VeVault is ReentrancyGuard, Pausable, IERC4626 {
      * @notice Mints shares Vault shares to receiver by depositing exactly 
      * amount of underlying tokens.
      * Only allow deposits for caller equals receiver.
-     * When a relock is performed, the furtherest date
-     * in the future is the one selected.
-     * The multiplier is applied to the total amount
-     * of assets deposited since all value will be locked.
+     * Relocks are only allowed if new unlock date is futherest
+     * in the future. If user tries to reduce its lock period
+     * the transaction will revert.
+     * The multiplier applied is always the one from the last
+     * deposit. And it's applied to the total amount deposited
+     * so far. It's not possible to have 2 unclock dates for 
+     * the same address.
      * @dev Compliant to the ERC4626 interface.
      * @param assets: amount of underlying tokens
      * @param receiver: address which the veTokens will be granted to
@@ -420,10 +423,13 @@ abstract contract VeVault is ReentrancyGuard, Pausable, IERC4626 {
      * @notice Mint shares for receiver by depositing
      * the necessary amount of underlying tokens.
      * Only allow deposits for caller equals receiver.
-     * When a relock is performed, the furtherest date
-     * in the future is the one selected.
-     * The multiplier is applied to the total amount
-     * of assets deposited since all value will be locked.
+     * Relocks are only allowed if new unlock date is futherest
+     * in the future. If user tries to reduce its lock period
+     * the transaction will revert.
+     * The multiplier applied is always the one from the last
+     * deposit. And it's applied to the total amount deposited
+     * so far. It's not possible to have 2 unclock dates for 
+     * the same address.
      * @dev Not compliant to the ERC4626 interface
      * since it doesn't mint the exactly amount
      * of shares asked. The shares amount stays

--- a/test/veNewoTests.ts
+++ b/test/veNewoTests.ts
@@ -400,7 +400,7 @@ describe("veNewo tests", async function () {
                         address(addr1),
                         days(0)
                     )
-            ).to.be.revertedWith("Unauthorized()");
+            ).to.be.revertedWith("LockTimeOutOfBounds(0, 7776000, 94608000)");
         });
         it("Deposit for 30 days should revert", async () => {
             await expect(
@@ -411,7 +411,7 @@ describe("veNewo tests", async function () {
                         address(addr1),
                         days(30)
                     )
-            ).to.be.revertedWith("Unauthorized()");
+            ).to.be.revertedWith("LockTimeOutOfBounds(2592000, 7776000, 94608000)");
         });
         it("Deposit for 4 years should revert", async () => {
             await expect(
@@ -422,7 +422,7 @@ describe("veNewo tests", async function () {
                         address(addr1),
                         years(4)
                     )
-            ).to.be.revertedWith("Unauthorized()");
+            ).to.be.revertedWith("LockTimeOutOfBounds(126144000, 7776000, 94608000)");
         });
     });
     

--- a/test/veNewoTests.ts
+++ b/test/veNewoTests.ts
@@ -587,12 +587,19 @@ describe("veNewo tests", async function () {
                 await veNewo.unlockDate(await addr1.getAddress())
                 ).to.equal(unlockDate);
         });
-        it("Relock for shorter period should keep the furthest date", async () => {
-            await userDeposit(days(90), parseNewo(0));
+        it("Relock for a shorter period is not allowed", async () => {
+            // await userDeposit(days(90), parseNewo(0));
+            await expect(
+                veNewo.connect(addr1)
+                ["deposit(uint256,address,uint256)"](
+                    parseNewo(amount),
+                    await addr1.getAddress(),
+                    days(90)
+                )).to.be.revertedWith("LockTimeLessThanCurrent(1682657560, 1658897561)");
             
-            expect(
-                await veNewo.unlockDate(await addr1.getAddress())
-                ).to.equal(unlockDate);
+            // expect(
+            //     await veNewo.unlockDate(await addr1.getAddress())
+            //     ).to.equal(unlockDate);
         });
     })
 

--- a/test/veNewoTests.ts
+++ b/test/veNewoTests.ts
@@ -610,8 +610,8 @@ describe("veNewo tests", async function () {
     testLock(years(3), days(30), 100);
     testKickUser(days(90), days(30), 100);
     testKickUser(years(3), days(30), 100);
-    testLockAndRelock(years(1), days(90), days(30), years(1), 50, 50);
-    testLockAndRelock(years(2), days(90), days(6 * 30), days(30), 57, 13);
+    testLockAndRelock(years(1), days(90), days(280), years(1), 50, 50);
+    testLockAndRelock(years(2), days(90), days(700), days(30), 57, 13);
     testLockAndRelock(days(90), days(90), days(88), days(90), 29, 157);
 
     /**


### PR DESCRIPTION
Now a deposit call allows for zero amount. This creates the possibility of a user do a relock, increasing the time locked without locking new tokens. New tests were added to cover this feature.